### PR TITLE
Add initial unit test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,34 @@
+name: tests
+on:
+  push:
+  pull_request:
+jobs:
+  OS:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        container:
+          - docker.io/debian:unstable
+          - registry.fedoraproject.org/fedora:rawhide
+
+    container:
+      image: ${{ matrix.container }}
+
+    timeout-minutes: 10
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Install build and test dependencies
+        run: |
+          if type apt >/dev/null 2>&1; then
+              apt-get update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-dbusmock libsystemd0
+          else
+              dnf install -y python3-dbusmock systemd-libs
+          fi
+
+      - name: Run tests
+        run: PYTHONPATH=. python3 test/test_*.py
+

--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ This projet aims to build a small wrapper around `libsystemd` based on `ctypes`,
 The initial focus is on the [`sd_event`](https://www.freedesktop.org/software/systemd/man/sd-event.html) and [`sd_bus`](https://www.freedesktop.org/software/systemd/man/sd-bus.html) APIs.
 
 This project originated as a weekend hack to support the efforts to write a portable Python version of [`cockpit-bridge`](https://cockpit-project.org/guide/latest/cockpit-bridge.1.html).
+
+Run tests with:
+
+    PYTHONPATH=. python3 test/test_*.py

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -1,0 +1,119 @@
+# systemd_ctypes
+#
+# Copyright (C) 2022 Martin Pitt <martin@piware.de>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import tempfile
+import unittest
+import sys
+
+import dbusmock
+import systemd_ctypes
+
+class TestAPI(dbusmock.DBusTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.start_session_bus()
+        cls.bus_user = systemd_ctypes.Bus.default_user()
+        cls.bus_user.attach_event(None, 0)
+
+    def setUp(self):
+        self.mock_log = tempfile.NamedTemporaryFile()
+        self.p_mock = self.spawn_server('org.freedesktop.Test',
+                                        '/',
+                                        'org.freedesktop.Test.Main',
+                                        stdout=self.mock_log)
+        self.addCleanup(self.p_mock.wait)
+        self.addCleanup(self.p_mock.terminate)
+
+    def assertLog(self, regex):
+        with open(self.mock_log.name, "rb") as f:
+            self.assertRegex(f.read(), regex)
+
+    def add_method(self, iface, name, in_sig, out_sig, code):
+        message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', dbusmock.MOCK_IFACE, 'AddMethod')
+        message.append('s', iface)
+        message.append('s', name)
+        message.append('s', in_sig)
+        message.append('s', out_sig)
+        message.append('s', code)
+        result = self.bus_user.call(message, -1)
+        self.assertEqual(result.get_body(), [])
+
+    def async_call(self, message):
+        loop = systemd_ctypes.Event.create_event_loop()
+
+        result = None
+        async def _call():
+            nonlocal result
+            result = await self.bus_user.call_async(message, 1000000)
+
+        loop.run_until_complete(_call())
+        return result
+
+    def test_noarg_noret_sync(self):
+        self.add_method('', 'Do', '', '', '')
+
+        message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Do')
+        result = self.bus_user.call(message, -1).get_body()
+        self.assertEqual(result, [])
+
+        self.assertLog(b'^[0-9.]+ Do$')
+
+    def test_noarg_noret_async(self):
+        self.add_method('', 'Do', '', '', '')
+
+        message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Do')
+        result = self.async_call(message).get_body()
+        self.assertEqual(result, [])
+
+        self.assertLog(b'^[0-9.]+ Do$')
+
+    def test_strarg_strret_sync(self):
+        self.add_method('', 'Reverse', 's', 's', 'ret = "".join(reversed(args[0]))')
+
+        message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Reverse')
+        message.append('s', 'ab c')
+        result = self.bus_user.call(message, -1).get_body()
+        self.assertEqual(result, ['c ba'])
+
+        self.assertLog(b'^[0-9.]+ Reverse "ab c"\n$')
+
+    def test_strarg_strret_async(self):
+        self.add_method('', 'Reverse', 's', 's', 'ret = "".join(reversed(args[0]))')
+
+        message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Reverse')
+        message.append('s', 'ab c')
+        result = self.async_call(message).get_body()
+        self.assertEqual(result, ['c ba'])
+
+        self.assertLog(b'^[0-9.]+ Reverse "ab c"\n$')
+
+    def test_unknown_method_sync(self):
+        message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Do')
+        with self.assertRaisesRegex(systemd_ctypes.BusError, '.*org.freedesktop.DBus.Error.UnknownMethod:.*'
+                'Do is not a valid method of interface org.freedesktop.Test.Main'):
+            self.bus_user.call(message, -1)
+
+    def test_unknown_method_async(self):
+        message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Do')
+        with self.assertRaisesRegex(systemd_ctypes.BusError, '.*org.freedesktop.DBus.Error.UnknownMethod:.*'
+                'Do is not a valid method of interface org.freedesktop.Test.Main'):
+            self.async_call(message).get_body()
+
+
+if __name__ == '__main__':
+    # avoid writing to stderr
+    unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))


### PR DESCRIPTION
This sets up a test harness with https://pypi.org/project/python-dbusmock/
and covers the basic API.
    
This already detects a crash with synchronous method calls. Disable
these tests by prefixing them with `crash_*`, so that unittest does not
run them by default.

---

This also adds a workflow which runs the tests on PRs and pushes. It [succeeds on Debian unstable and Fedora rawhide](https://github.com/martinpitt/systemd_ctypes/actions/runs/2450233096) on my fork. You won't see the result in this PR until your main branch contains the workflow.

With an [extra commit](https://github.com/martinpitt/systemd_ctypes/commit/3a1f5c48da2b7de04f4aae2b05e7dc067f1d44ce) that enables the two "crash" tests, they [fail as expected](https://github.com/martinpitt/systemd_ctypes/actions/runs/2450227721).