### PR TITLE
test: Add ARM v7 (32 bit) and s390x (big-endian) test run, cover all basic data types

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,7 @@ on:
 jobs:
   OS:
     runs-on: ubuntu-latest
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:
@@ -31,3 +32,30 @@ jobs:
 
       - name: Run tests
         run: test/run
+
+  arch:
+    runs-on: ubuntu-latest
+    permissions: {}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          # 32 bit
+          - armv7
+          # big-endian
+          - s390x
+
+    timeout-minutes: 10
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Run test
+        uses: uraimo/run-on-arch-action@v2
+        with:
+          distro: ubuntu_latest
+          arch: ${{ matrix.arch }}
+          install: |
+            apt-get update
+            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-dbusmock libsystemd0
+          run: test/run

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -149,6 +149,12 @@ class TestAPI(dbusmock.DBusTestCase):
         with self.assertRaisesRegex(systemd_ctypes.BusError, "OverflowError: can't convert negative value to unsigned int"):
             self.bus_user.call(message, -1)
 
+    def test_float(self):
+        self.add_method('', 'Sq', 'd', 'd', 'ret = args[0] * args[0]')
+        message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Sq')
+        message.append('d', -5.5)
+        self.assertAlmostEqual(self.async_call(message).get_body()[0], 30.25)
+
     def test_unknown_method_sync(self):
         message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Do')
         with self.assertRaisesRegex(systemd_ctypes.BusError, '.*org.freedesktop.DBus.Error.UnknownMethod:.*'

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -111,26 +111,28 @@ class TestAPI(dbusmock.DBusTestCase):
             self.assertEqual(result, (not val,))
 
     def test_int_sync(self):
-        self.add_method('', 'Inc', 'iuxt', 'iuxt', 'ret = (args[0] + 1, args[1] + 1, args[2] + 1, args[3] + 1)')
+        self.add_method('', 'Inc', 'yiuxt', 'yiuxt', 'ret = (args[0] + 1, args[1] + 1, args[2] + 1, args[3] + 1, args[4] + 1)')
 
         message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Inc')
+        message.append('y', 0x7E)
         message.append('i', 0x7FFFFFFE)
         message.append('u', 0xFFFFFFFE)
         message.append('x', 0x7FFFFFFFFFFFFFFE)
         message.append('t', 0xFFFFFFFFFFFFFFFE)
         result = self.bus_user.call(message, -1).get_body()
-        self.assertEqual(result, (0x7FFFFFFF, 0xFFFFFFFF, 0x7FFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF))
+        self.assertEqual(result, (0x7F, 0x7FFFFFFF, 0xFFFFFFFF, 0x7FFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF))
 
     def test_int_async(self):
-        self.add_method('', 'Inc', 'iuxt', 'iuxt', 'ret = (args[0] + 1, args[1] + 1, args[2] + 1, args[3] + 1)')
+        self.add_method('', 'Inc', 'yiuxt', 'yiuxt', 'ret = (args[0] + 1, args[1] + 1, args[2] + 1, args[3] + 1, args[4] + 1)')
 
         message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Inc')
+        message.append('y', 0x7E)
         message.append('i', 0x7FFFFFFE)
         message.append('u', 0xFFFFFFFE)
         message.append('x', 0x7FFFFFFFFFFFFFFE)
         message.append('t', 0xFFFFFFFFFFFFFFFE)
         result = self.async_call(message).get_body()
-        self.assertEqual(result, (0x7FFFFFFF, 0xFFFFFFFF, 0x7FFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF))
+        self.assertEqual(result, (0x7F, 0x7FFFFFFF, 0xFFFFFFFF, 0x7FFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF))
 
     def test_unknown_method_sync(self):
         message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Do')

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -123,16 +123,16 @@ class TestAPI(dbusmock.DBusTestCase):
         self.assertEqual(result, (0x7F, 0x7FFFFFFF, 0xFFFFFFFF, 0x7FFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF))
 
     def test_int_async(self):
-        self.add_method('', 'Inc', 'yiuxt', 'yiuxt', 'ret = (args[0] + 1, args[1] + 1, args[2] + 1, args[3] + 1, args[4] + 1)')
+        self.add_method('', 'Dec', 'yiuxt', 'yiuxt', 'ret = (args[0] - 1, args[1] - 1, args[2] - 1, args[3] - 1, args[4] - 1)')
 
-        message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Inc')
-        message.append('y', 0x7E)
-        message.append('i', 0x7FFFFFFE)
-        message.append('u', 0xFFFFFFFE)
-        message.append('x', 0x7FFFFFFFFFFFFFFE)
-        message.append('t', 0xFFFFFFFFFFFFFFFE)
+        message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Dec')
+        message.append('y', 1)
+        message.append('i', -0x7FFFFFFF)
+        message.append('u', 1)
+        message.append('x', -0x7FFFFFFFFFFFFFFF)
+        message.append('t', 1)
         result = self.async_call(message).get_body()
-        self.assertEqual(result, (0x7F, 0x7FFFFFFF, 0xFFFFFFFF, 0x7FFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF))
+        self.assertEqual(result, (0, -0x80000000, 0, -0x8000000000000000, 0))
 
     def test_unknown_method_sync(self):
         message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Do')

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -155,6 +155,12 @@ class TestAPI(dbusmock.DBusTestCase):
         message.append('d', -5.5)
         self.assertAlmostEqual(self.async_call(message).get_body()[0], 30.25)
 
+    def test_objpath(self):
+        self.add_method('', 'Parent', 'o', 'o', "ret = '/'.join(args[0].split('/')[:-1])")
+        message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Parent')
+        message.append('o', '/foo/bar/baz')
+        self.assertEqual(self.async_call(message).get_body(), ('/foo/bar',))
+
     def test_unknown_method_sync(self):
         message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Do')
         with self.assertRaisesRegex(systemd_ctypes.BusError, '.*org.freedesktop.DBus.Error.UnknownMethod:.*'

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -173,6 +173,12 @@ class TestAPI(dbusmock.DBusTestCase):
                 'Do is not a valid method of interface org.freedesktop.Test.Main'):
             self.async_call(message).get_body()
 
+    def test_custom_error(self):
+        self.add_method('', 'Boom', '', '', 'raise dbus.exceptions.DBusException("no good", name="com.example.Error.NoGood")')
+        message = self.bus_user.message_new_method_call('org.freedesktop.Test', '/', 'org.freedesktop.Test.Main', 'Boom')
+        with self.assertRaisesRegex(systemd_ctypes.BusError, 'no good'):
+            self.bus_user.call(message, -1)
+
 
 if __name__ == '__main__':
     # avoid writing to stderr


### PR DESCRIPTION
Using https://github.com/marketplace/actions/run-on-architecture. Run
with no permissions, so that we don't need to be overly concerned about
this third-party action.

----

This is pretty nice! I'm also positively surpised that this just works, I had expected more trouble with endianess and ctypes and such. But I figure it all cancels out.