### PR TITLE
workflows: Move arm/s390x tests from Ubuntu LTS to Fedora

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,9 +53,7 @@ jobs:
       - name: Run test
         uses: uraimo/run-on-arch-action@v2
         with:
-          distro: ubuntu_latest
+          distro: fedora_latest
           arch: ${{ matrix.arch }}
-          install: |
-            apt-get update
-            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-dbusmock libsystemd0
+          install: dnf install -y python3-dbusmock systemd-libs
           run: test/run


### PR DESCRIPTION
Commit c65c34f5414 introduced sd_event_add_inotify_fd(), but this was
only added *very* recently in systemd 250, and thus is not available yet
in most distros (only in Debian testing and Fedora 36/rawhide).

Thus move the "foreign architecture" integration tests from Ubuntu LTS
to Fedora , which already has systemd 250.

---

See [failed tests on main](https://github.com/allisonkarlitskaya/systemd_ctypes/runs/7062082557?check_suite_focus=true).

dnf is much slower than apt, and some variety in the OSes wouldn't hurt, but here we are.. We can bring this back when systemd 250 is a bit more common, or perhaps find a solution that uses `sd_event_add_inotify()` only, which is available since systemd 239.