### PR TITLE
Fix code for Python 3.6 and run tests on CentOS 8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,6 +12,7 @@ jobs:
         container:
           - docker.io/debian:unstable
           - registry.fedoraproject.org/fedora:rawhide
+          - quay.io/centos/centos:stream8
 
     container:
       image: ${{ matrix.container }}
@@ -26,6 +27,9 @@ jobs:
           if type apt >/dev/null 2>&1; then
               apt-get update
               DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-dbusmock libsystemd0
+          elif grep -q platform:el8 /etc/os-release; then
+              dnf install -y python3-pip systemd-libs
+              pip3 install python-dbusmock==0.26.1
           else
               dnf install -y python3-dbusmock systemd-libs
           fi

--- a/systemd_ctypes/bus.py
+++ b/systemd_ctypes/bus.py
@@ -19,6 +19,7 @@ import asyncio
 import base64
 import itertools
 import logging
+import sys
 from ctypes import c_char, byref
 
 from .librarywrapper import utf8
@@ -115,7 +116,9 @@ class Slot(sd.bus_slot):
 class PendingCall(Slot):
     def __init__(self):
         super().__init__(self.done)
-        self.future = asyncio.get_running_loop().create_future()
+
+        get_loop = asyncio.get_running_loop if sys.version_info >= (3, 7, 0) else asyncio.get_event_loop
+        self.future = get_loop().create_future()
 
     def done(self, message):
         if message.is_method_error(None):

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -57,7 +57,12 @@ class TestAPI(dbusmock.DBusTestCase):
             nonlocal result
             result = await self.bus_user.call_async(message)
 
-        asyncio.run(_call())
+        if sys.version_info >= (3, 7, 0):
+            asyncio.run(_call())
+        else:
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(_call())
+
         return result
 
     def test_noarg_noret_sync(self):

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -176,5 +176,4 @@ class TestAPI(dbusmock.DBusTestCase):
 
 
 if __name__ == '__main__':
-    # avoid writing to stderr
-    unittest.main(testRunner=unittest.TextTestRunner(stream=sys.stdout))
+    unittest.main()


### PR DESCRIPTION
Tested locally with

    podman run -it --rm -v .:/source -w /source quay.io/centos/centos:stream8 sh -exc 'dnf install -y python3-pip systemd-libs; pip3 install python-dbusmock==0.26.1; test/run'

Fortunately, no walruses were harmed during the production of this mov^WPR!

![walrus](https://i.imgflip.com/xlhd3.jpg)