### PR TITLE
introspection: only parse <arg>

### DIFF
--- a/systemd_ctypes/introspection.py
+++ b/systemd_ctypes/introspection.py
@@ -32,7 +32,7 @@ def parse_property(prop):
 
 
 def parse_signal(signal):
-    return {"in": [tag.attrib['type'] for tag in signal]}
+    return {"in": [tag.attrib['type'] for tag in signal.findall("arg")]}
 
 
 def parse_interface(interface):


### PR DESCRIPTION
Sometimes when introspecting a DBus signal field it includes an
"annotation" field which has no type that causes a KeyError.

For example:

```
<signal name="Details">
      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap">
      </annotation>
      <arg type="a{sv}" name="data">
      </arg>
    </signal>
```