### PR TITLE
bus: Raise new InvalidArgsError when constructing messages

### DIFF
--- a/systemd_ctypes/__init__.py
+++ b/systemd_ctypes/__init__.py
@@ -22,6 +22,7 @@ __version__ = "0"
 from .bus import Bus, BusError, BusMessage
 from .event import Event, EventLoopPolicy, run_async
 from .pathwatch import PathWatch
+from .libsystemd import InvalidArgsError
 
 __all__ = [
         "Bus",
@@ -30,5 +31,6 @@ __all__ = [
         "Event",
         "EventLoopPolicy",
         "PathWatch",
+        "InvalidArgsError",
         "run_async",
 ]

--- a/systemd_ctypes/bus.py
+++ b/systemd_ctypes/bus.py
@@ -53,7 +53,14 @@ class BusMessage(sd.bus_message):
         if category == 'a' and contents == 'y' and isinstance(value, str):
             value = base64.b64decode(value)
 
-        # Containers
+        # Variants
+        if category == 'v':
+            self.open_container(ord(category), value['t'])
+            self.append_with_info(parse_typestring(value['t']), value['v'])
+            self.close_container()
+            return
+
+        # Other containers
         child_info_iter = itertools.repeat(child_info) if category == 'a' else child_info
         value_iter = value.items() if child_info[0] == 'e' else value
 


### PR DESCRIPTION
This is a pile of hacks that are supposed to raise a specific error (InvalidArgsError) when a method call is made with invalid args.
