### PR TITLE
pytest: set log_cli = true

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dynamic = ["version", "description"]
 [project.urls]
 Home = "https://github.com/allisonkarlitskaya/systemd_ctypes/"
 
+[tool.pytest.ini_options]
+log_cli = true
+
 [tool.tox]
 legacy_tox_ini = """
 [tox]


### PR DESCRIPTION
ctypes and callbacks don't mix particularly well with exceptions and pytest.  The best ctypes can do when an exception occurs in a callback is to log it to stderr and return from the callback.

In case that happened during a D-Bus method call, for example, then the reply won't be sent, and the call will hang.

When you're running the test code directly, this is OK, because you'll see the exception, but pytest normally captures this output and presents it at the end of the test, in the case that the test failed.  This means that you're waiting for the hung call to return, and not seeing the reason why.

Set log_cli = true in order to allow us to see the failing log output immediately.