### PR TITLE
bus: up our object-exporting game

### DIFF
--- a/systemd_ctypes/libsystemd.py
+++ b/systemd_ctypes/libsystemd.py
@@ -142,6 +142,7 @@ sd.bus.register_methods([
     (instancemethod, negative_errno, 'flush', []),
     (instancemethod, negative_errno, 'message_new', [POINTER(sd.bus_message_p), c_uint8]),
     (instancemethod, negative_errno, 'message_new_method_call', [POINTER(sd.bus_message_p), utf8, utf8, utf8, utf8]),
+    (instancemethod, negative_errno, 'message_new_signal', [POINTER(sd.bus_message_p), utf8, utf8, utf8]),
     (instancemethod, negative_errno, 'new', [POINTER(sd.bus_p)]),
     (instancemethod, negative_errno, 'set_fd', [c_int, c_int]),
     (instancemethod, negative_errno, 'set_server', [boolint, sd.id128]),


### PR DESCRIPTION
Add a series of new helper types to make it nicer to export objects on the bus.  There is now signals support, and simplified support for properties (not requiring getters or setters).

The interface decorator has been removed and replaced with a new approach: each interface should be defined in its own subclass, and the interface name is derived from the subclass name (with support for overrides via kwarg=).

We add the standard Introspectable, Peer, and Properties interfaces via the new mechanism and now define our 'Object' type as a BaseObject which additionally provides all of those interfaces, as well as giving the user a base to define their own interface (or interfaces).

Documentation has been expanded, and examples added.

There's also a .registered() method to notify an object when it joins the bus.