### PR TITLE
bus: Avoid reference loops in Slot and PendingCall

### DIFF
--- a/src/systemd_ctypes/libsystemd.py
+++ b/src/systemd_ctypes/libsystemd.py
@@ -140,6 +140,7 @@ sd.bus.register_methods([
     (instancemethod, negative_errno, 'call', [sd.bus_message_p, c_uint64, POINTER(sd.bus_error), POINTER(sd.bus_message_p)]),
     (instancemethod, negative_errno, 'call_async', [POINTER(sd.bus_slot), sd.bus_message_p, sd.bus_message_handler_t, c_void_p, c_uint64]),
     (instancemethod, negative_errno, 'flush', []),
+    (instancemethod, negative_errno, 'get_fd', []),
     (instancemethod, negative_errno, 'message_new', [POINTER(sd.bus_message_p), c_uint8]),
     (instancemethod, negative_errno, 'message_new_method_call', [POINTER(sd.bus_message_p), utf8, utf8, utf8, utf8]),
     (instancemethod, negative_errno, 'message_new_signal', [POINTER(sd.bus_message_p), utf8, utf8, utf8]),

--- a/test/test_p2p.py
+++ b/test/test_p2p.py
@@ -197,6 +197,15 @@ class CommonTests:
 
         run_async(test())
 
+    def test_unexport(self):
+        async def test():
+            # Make sure that dropping the slot results in the object being un-exported
+            self.test_object_slot = None
+
+            with self.assertRaisesRegex(BusError, "org.freedesktop.DBus.Error.UnknownObject: Unknown object '/test'."):
+                await self.client.call_method_async(None, '/test', 'cockpit.Test', 'Divide', 'ii', 1554, 37)
+        run_async(test())
+
 
 class TestAddress(CommonTests, unittest.TestCase):
     def setUp(self):

--- a/test/test_refloop.py
+++ b/test/test_refloop.py
@@ -1,0 +1,93 @@
+import errno
+import gc
+import os
+import unittest
+
+import socket
+from systemd_ctypes import bus
+
+
+def fd_closed(fd: int, old_stat: os.stat_result) -> bool:
+    try:
+        new_stat = os.fstat(fd)
+    except OSError as exc:
+        # If it is EBADF then it got closed!  Good!
+        if exc.errno == errno.EBADF:
+            return True
+
+    # Otherwise, maybe someone opened a new file.  Let's compare the stats.
+    return new_stat != old_stat
+
+
+class Router:
+    slot: bus.Slot
+
+
+class Exportee(bus.BaseObject):
+    router: Router
+
+
+# Check for proper freeing of bus objects when references go out of scope.
+# Used to make sure we don't form accidental reference loops.
+class TestReferences(unittest.TestCase):
+    def setUp(self):
+        client_socket, server_socket = socket.socketpair()
+        self.client = bus.Bus.new(fd=client_socket.detach())
+        self.server = bus.Bus.new(fd=server_socket.detach(), server=True)
+        self.and_gc = False
+        self.extra_refs = []
+
+    def tearDown(self):
+        client_fd = self.client.get_fd()
+        client_stat = os.fstat(client_fd)
+
+        server_fd = self.server.get_fd()
+        server_stat = os.fstat(server_fd)
+
+        # This should result in both ends closing.
+        del self.client
+        del self.server
+        del self.extra_refs
+
+        # Make sure the GC is the thing that solves this one.
+        if self.and_gc:
+            # At least one should still be open at this point
+            assert not fd_closed(client_fd, client_stat) or not fd_closed(server_fd, server_stat)
+            gc.enable()
+            gc.collect()
+            # ...but at this point they should both be closed
+
+        assert fd_closed(client_fd, client_stat)
+        assert fd_closed(server_fd, server_stat)
+
+    def test_export_no_save(self):
+        self.server.add_object('/foo', bus.BaseObject())
+
+    def test_export_and_cancel(self):
+        slot = self.server.add_object('/foo', bus.BaseObject())
+        slot.cancel()
+
+    def test_export_cancel_and_save(self):
+        slot = self.server.add_object('/foo', bus.BaseObject())
+        slot.cancel()
+        self.extra_refs.append(slot)
+
+    def test_export_save(self):
+        slot = self.server.add_object('/foo', bus.BaseObject())
+        self.extra_refs.append(slot)
+
+    def test_gc_required(self) -> None:
+        # Test a case of some objects referencing each other and make sure that
+        #
+        #   1) The cycle isn't resolved merely by unref (we disable GC for that)
+        #
+        #   2) Manually running the GC does indeed clear the cycle
+
+        gc.disable()
+        self.and_gc = True
+
+        router = Router()
+        exportee = Exportee()
+        exportee.router = router
+        router.slot = self.server.add_object('/foo', exportee)
+        self.extra_refs.append(router)


### PR DESCRIPTION
Instead of taking an indirect references on ourselves via bound method calls, use closures in the form of nested functions.

This means that the Slot can be immediately freed on unref, without waiting for the GC to run.  That's important, since this can result in the bus being held open, otherwise.

All the same, let's add an explicit .cancel() method there as another way of releasing the slot.  This shouldn't be required.

Add a previously failing test-case for unexporting.

Note: we handle the reference to the closure completely within the Python realm, and C has absolutely no reference to anything — just a dangling pointer.  We know that when the Slot goes out of scope, we'll unref the slot in C, which will prevent further callbacks, so this should be safe.  The reason we want to keep all references inside of Python (instead of using the somewhat safer destroy notify mechanism from C, for example) is to allow the GC to detect and bust cycles.  We add a somewhat exotic testcase to verify that the GC (and only the GC) is capable of busting exactly the cycles, in a way similar to how this will be used from Cockpit.