### PR TITLE
bus: Bind name owning/releasing

### DIFF
--- a/examples/dbus-service.py
+++ b/examples/dbus-service.py
@@ -1,0 +1,46 @@
+# systemd_ctypes
+#
+# Copyright (C) 2023 Martin Pitt <mpitt@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# once this runs, test with:
+# busctl --user call com.example.Test / com.example.Test HelloWorld s "World"
+
+import asyncio
+
+from systemd_ctypes import bus, run_async
+
+
+class com_example_Test(bus.Object):
+    @bus.Interface.Method('s', 's')
+    def hello_world(self, name):
+        return f'Hello {name}!'
+
+
+async def main():
+    user_bus = bus.Bus.default_user()
+
+    test_object = com_example_Test()
+    test_slot = user_bus.add_object('/', test_object)
+
+    user_bus.request_name('com.example.Test', 0)
+
+    await asyncio.sleep(30)
+
+    user_bus.release_name('com.example.Test')
+    del test_slot
+
+
+run_async(main())

--- a/src/systemd_ctypes/bus.py
+++ b/src/systemd_ctypes/bus.py
@@ -17,6 +17,7 @@
 
 import asyncio
 import base64
+import enum
 import functools
 import itertools
 import logging
@@ -307,6 +308,12 @@ class PendingCall(Slot):
 class Bus(sd.bus):
     _default_system = None
     _default_user = None
+
+    class NameFlags(enum.IntFlag):
+        DEFAULT = 0
+        REPLACE_EXISTING = 1 << 0
+        ALLOW_REPLACEMENT = 1 << 1
+        QUEUE = 1 << 2
 
     @staticmethod
     def new(fd=None, address=None, bus_client=False, server=False, start=True, attach_event=True):

--- a/src/systemd_ctypes/libsystemd.py
+++ b/src/systemd_ctypes/libsystemd.py
@@ -153,6 +153,8 @@ sd.bus.register_methods([
     (instancemethod, negative_errno, 'message_new_method_call', [POINTER(sd.bus_message_p), utf8, utf8, utf8, utf8]),
     (instancemethod, negative_errno, 'message_new_signal', [POINTER(sd.bus_message_p), utf8, utf8, utf8]),
     (instancemethod, negative_errno, 'new', [POINTER(sd.bus_p)]),
+    (instancemethod, negative_errno, 'release_name', [utf8]),
+    (instancemethod, negative_errno, 'request_name', [utf8, c_uint64]),
     (instancemethod, negative_errno, 'set_address', [utf8]),
     (instancemethod, negative_errno, 'set_bus_client', [boolint]),
     (instancemethod, negative_errno, 'set_fd', [c_int, c_int]),


### PR DESCRIPTION
This is the synchronous API, which should usually be good enough (not much else can happen in parallel anyway), and easier to use than the async one.

---

This should unblock porting Cockpit's D-Bus mock server out of test-server.c into its own standalone Python program.