### PR TITLE
bus: add support for OSError exceptions

### DIFF
--- a/src/systemd_ctypes/libsystemd.py
+++ b/src/systemd_ctypes/libsystemd.py
@@ -93,6 +93,7 @@ sd.bus_message.register_methods([
     (instancemethod, negative_errno, 'exit_container', []),
     (instancemethod, negative_errno, 'has_signature', [utf8]),
     (instancemethod, negative_errno, 'is_method_error', [utf8]),
+    (instancemethod, negative_errno, 'new_method_errnof', [POINTER(sd.bus_message_p), c_int, utf8, utf8]),
     (instancemethod, negative_errno, 'new_method_errorf', [POINTER(sd.bus_message_p), utf8, utf8, utf8]),
     (instancemethod, negative_errno, 'new_method_return', [POINTER(sd.bus_message_p)]),
     (instancemethod, negative_errno, 'open_container', [c_char, utf8]),

--- a/test/test_p2p.py
+++ b/test/test_p2p.py
@@ -53,6 +53,11 @@ class CommonTests:
             async def do_nothing_slowly(self):
                 await asyncio.sleep(0.1)
 
+            @bus.Interface.Method('s', 's')
+            def read_file(self, filename: str) -> str:
+                with open(filename) as fp:
+                    return fp.read()
+
             everything_changed = bus.Interface.Signal('i', 's')
 
         self.test_object = cockpit_Test()
@@ -111,6 +116,7 @@ class CommonTests:
                         'PartitionSlowly': {'in': ['s', 's'], 'out': ['s', 's', 's']},
                         'DoNothing': {'in': [], 'out': []},
                         'DoNothingSlowly': {'in': [], 'out': []},
+                        'ReadFile': {'in': ['s'], 'out': ['s']},
                     },
                     'properties': {
                         'Answer': {'type': 'i', 'flags': 'r'},
@@ -174,6 +180,12 @@ class CommonTests:
         async def test():
             with self.assertRaisesRegex(BusError, 'cockpit.Error.ZeroDivisionError: Divide by zero'):
                 await self.client.call_method_async(None, '/test', 'cockpit.Test', 'Divide', 'ii', 1554, 0)
+        run_async(test())
+
+    def test_method_throws_oserror(self):
+        async def test():
+            with self.assertRaisesRegex(BusError, 'org.freedesktop.DBus.Error.FileNotFound: .*notthere.*'):
+                await self.client.call_method_async(None, '/test', 'cockpit.Test', 'ReadFile', 's', 'notthere')
         run_async(test())
 
     def test_async_method(self):


### PR DESCRIPTION
Allow passing OSError to various 'error reply' functions, as well as catching it and forwarding it from method calls exported on the bus.

The error will be converted to the usual org.freedesktop.DBus.Error message based on its errno and the str() form of the exception will be used as its message.