### PR TITLE
systemd_ctypes: drop leftover debug prints

### DIFF
--- a/src/systemd_ctypes/bus.py
+++ b/src/systemd_ctypes/bus.py
@@ -142,7 +142,6 @@ class BusMessage(libsystemd.sd_bus_message):
         :returns: an n-tuple containing one value per argument in the message
         """
         self.rewind(True)
-        print(self.get_signature(True))
         types = bustypes.from_signature(self.get_signature(True))
         return tuple(type_.reader(self) for type_ in types)
 

--- a/src/systemd_ctypes/librarywrapper.py
+++ b/src/systemd_ctypes/librarywrapper.py
@@ -208,7 +208,6 @@ class ReferenceType(ctypes.c_void_p):
 
     @classmethod
     def ref(cls: Type[T], origin: WeakReference) -> T:
-        print(origin)
         self = cls(origin)
         self._ref()
         return self


### PR DESCRIPTION
Let's see if this unbreaks the Python bridge