### PR TITLE
Be careful about freeing callback trampolines

### DIFF
--- a/src/systemd_ctypes/librarywrapper.py
+++ b/src/systemd_ctypes/librarywrapper.py
@@ -152,9 +152,6 @@ class ReferenceType(ctypes.c_void_p):
     def _install_cfuncs(cls, cdll: ctypes.CDLL) -> None:
         logger.debug('Installing stubs for %s:', cls)
         stubs = tuple(cls.__dict__.items())
-        if cls.__name__ == 'sd_bus':
-            assert True, stubs
-
         for name, stub in stubs:
             if name.startswith("__"):
                 continue

--- a/test/test_p2p.py
+++ b/test/test_p2p.py
@@ -179,13 +179,13 @@ class CommonTests:
 
     def test_method_throws(self):
         async def test():
-            with self.assertRaisesRegex(BusError, 'cockpit.Error.ZeroDivisionError: Divide by zero'):
+            with pytest.raises(BusError, match='cockpit.Error.ZeroDivisionError: Divide by zero'):
                 await self.client.call_method_async(None, '/test', 'cockpit.Test', 'Divide', 'ii', 1554, 0)
         run_async(test())
 
     def test_method_throws_oserror(self):
         async def test():
-            with self.assertRaisesRegex(BusError, 'org.freedesktop.DBus.Error.FileNotFound: .*notthere.*'):
+            with pytest.raises(BusError, match='org.freedesktop.DBus.Error.FileNotFound: .*notthere.*'):
                 await self.client.call_method_async(None, '/test', 'cockpit.Test', 'ReadFile', 's', 'notthere')
         run_async(test())
 
@@ -206,7 +206,7 @@ class CommonTests:
 
     def test_async_method_throws(self):
         async def test():
-            with self.assertRaisesRegex(BusError, 'cockpit.Error.ZeroDivisionError: Divide by zero'):
+            with pytest.raises(BusError, match='cockpit.Error.ZeroDivisionError: Divide by zero'):
                 await self.client.call_method_async(None, '/test', 'cockpit.Test', 'DivideSlowly', 'ii', 1554, 0)
         run_async(test())
 
@@ -249,8 +249,7 @@ class CommonTests:
             # Make sure that dropping the slot results in the object being un-exported
             self.test_object_slot = None
 
-            with self.assertRaisesRegex(
-                    BusError, "org.freedesktop.DBus.Error.UnknownObject: Unknown object '/test'."):
+            with pytest.raises(BusError, match="org.freedesktop.DBus.Error.UnknownObject: Unknown object '/test'."):
                 await self.client.call_method_async(None, '/test', 'cockpit.Test', 'Divide', 'ii', 1554, 37)
         run_async(test())
 


### PR DESCRIPTION
Our approach to handling Source and Slot objects is fairly clever: we
tie the call trampoline and closure to the same object that holds a
reference to the source object on the C side.  When we are about to
`__del__()` that object, we unref the source, preventing any further
events from being dispatched.  In this way, we can be completely sure
that systemd will never call our trampoline after it's been freed.

Unfortunately, this isn't good enough: we have a lot of cases where we
free a Source while it is currently being dispatched.  Until now we've
never noticed a problem, but Cockpit recently added a stress-test for
inotify (`test_fsinfo_watch_identity_changes`) which dispatches thousand
of events and runs long enough that garbage collection gets invoked,
freeing trampolines while they are currently running.  Python does not
hold a reference to the data, and this causes crashes on some
architectures.

Let's give Source and Slot a common base class (Trampoline) that models
their common behaviour.  This helper class also changes the `__del__()`
behaviour: in case some external caller has requested deferral of the
destruction of trampolines, we add them to a list just before we get
deleted, to prevent the FFI wrapper from being destroyed with us.

We know that the problem described above is only a problem if we're
dispatching from systemd's event loop, so setup deferral on entry to the
loop and drop the deferred objects on exit.

Closes #63
