### PR TITLE
use hardened xml parser defusedxml

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,7 @@ jobs:
               DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
                   flit \
                   libsystemd0 \
+                  python3-defusedxml \
                   python3-dbusmock \
                   python3-pytest \
                   python3-pytest-cov \
@@ -48,6 +49,7 @@ jobs:
                   systemd-libs
               pip3 install \
                   flit \
+                  defusedxml \
                   pytest \
                   pytest-cov \
                   python-dbusmock \
@@ -56,6 +58,7 @@ jobs:
               dnf install -y \
                   python3-dbusmock \
                   python3-flit \
+                  python3-defusedxml \
                   python3-pytest \
                   python3-pytest-cov \
                   systemd-libs \
@@ -92,6 +95,7 @@ jobs:
             DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
                 flit \
                 libsystemd0 \
+                python3-defusedxml \
                 python3-dbusmock \
                 python3-pytest-cov \
                 tox

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -105,7 +105,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Install system dependencies
-        run: sudo dnf install -y dbus-daemon dbus-devel gcc glib2-devel tox
+        run: sudo dnf install -y dbus-daemon dbus-devel gcc glib2-devel python3-devel tox
 
       - name: Clone repository
         uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 license = {file = "COPYING"}
 classifiers = ["License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"]
 dynamic = ["version", "description"]
+dependencies = ["defusedxml"]
 
 [project.urls]
 Home = "https://github.com/allisonkarlitskaya/systemd_ctypes/"
@@ -94,6 +95,8 @@ package = wheel
 wheel_build_env = venv-pkg
 skip_install = mypy,pycodestyle,ruff: True
 deps =
+  pytest,mypy: defusedxml
+  mypy: types-defusedxml
   pytest,mypy: pytest-cov
   pytest,mypy: python-dbusmock
   mypy: mypy

--- a/src/systemd_ctypes/introspection.py
+++ b/src/systemd_ctypes/introspection.py
@@ -17,6 +17,8 @@
 
 import xml.etree.ElementTree as ET
 
+import defusedxml.ElementTree as DET
+
 
 def parse_method(method):
     return {
@@ -45,7 +47,7 @@ def parse_interface(interface):
 
 
 def parse_xml(xml):
-    et = ET.fromstring(xml)
+    et = DET.fromstring(xml)
     return {tag.attrib['name']: parse_interface(tag) for tag in et.findall('interface')}
 
 


### PR DESCRIPTION
It took entirely too long, but currently released OS distributions now have a safe by default ElementTree, but I think this may be used by some people on older systems that are still vulnerable by shipping it via ssh to that old system from a new system with cockpit.

The xml here comes from something that is in a normal configuration not untrusted (a process running as a local user receives the xml from the systems dbus/systemd instance) and it doesn't cross a possible security boundary between cockpit-bridge and cockpit-ws, as this is probably only used in cockpit-bridge. On the other hand this is published on pypi.

I considered if this is not needed, overall if this change just works, it is probably still a good idea.