### PR TITLE
Fix CI failing to build dbus-python

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -105,7 +105,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Install system dependencies
-        run: sudo dnf install -y dbus-daemon dbus-devel gcc glib2-devel tox
+        run: sudo dnf install -y dbus-daemon dbus-devel gcc glib2-devel python3-devel tox
 
       - name: Clone repository
         uses: actions/checkout@v3


### PR DESCRIPTION
by installing required python3-devel package