### PR TITLE
tests: Drop EOL CentOS 8, add CentOS 10

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,8 +18,8 @@ jobs:
           - docker.io/ubuntu:rolling
           - docker.io/ubuntu:latest
           - registry.fedoraproject.org/fedora:rawhide
-          - quay.io/centos/centos:stream8
           - quay.io/centos/centos:stream9
+          - quay.io/centos/centos:stream10-development
 
     container:
       image: ${{ matrix.container }}


### PR DESCRIPTION
This fixes the [recent test failures](https://github.com/allisonkarlitskaya/systemd_ctypes/actions/runs/9384933420). @allisonkarlitskaya you pinged me about it yesterday, but I forgot about the [CentOS 8 EOL](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/).