### PR TITLE
examples: don't attach_event twice

### DIFF
--- a/examples/dbus-client-hostnamed.py
+++ b/examples/dbus-client-hostnamed.py
@@ -27,7 +27,6 @@ def property_changed(message):
 
 async def main():
     system = Bus.default_system()
-    system.attach_event(None, 0)
 
     xml, = system.call_method('org.freedesktop.hostname1',
                               '/org/freedesktop/hostname1',


### PR DESCRIPTION
Bus.default_system already calls the same code which leads to an OSError.

Closes: #70